### PR TITLE
Add FastAPI Flink SQL proxy and dbt HTTP adapter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+
+COPY proxy/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY proxy /app/proxy
+ENV PYTHONPATH=/app
+
+EXPOSE 8080
+CMD ["uvicorn", "proxy.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+COMPOSE ?= docker compose
+COMPOSE_DIR ?= envs/flink-1.16
+
+.PHONY: up logs down
+
+up:
+cd $(COMPOSE_DIR) && $(COMPOSE) up -d --build
+
+logs:
+cd $(COMPOSE_DIR) && $(COMPOSE) logs -f flink-sql-proxy jobmanager
+
+down:
+cd $(COMPOSE_DIR) && $(COMPOSE) down -v

--- a/adapter/README.md
+++ b/adapter/README.md
@@ -1,0 +1,28 @@
+# dbt-flink-http-adapter (hackathon edition)
+
+This minimal adapter wraps the FastAPI proxy exposed in `proxy/` so that dbt can issue
+compiled SQL statements to a Flink cluster over HTTP. It intentionally omits catalog
+inspection and most advanced adapter features – the goal is to demonstrate the plumbing
+required for `dbt run` against a long running Flink application job managed by the proxy.
+
+## Installation
+
+```bash
+pip install -e adapter/
+```
+
+## Profiles.yml snippet
+
+```yaml
+project:
+  target: dev
+  outputs:
+    dev:
+      type: flink_http
+      host: http://flink-sql-proxy:8080
+      token: ${AUTH_TOKEN}
+      schema: default_database
+      database: default_catalog
+```
+
+See `examples/dbt_http_demo` for a tiny dbt project wired to the adapter.

--- a/adapter/dbt_flink_http_adapter/__init__.py
+++ b/adapter/dbt_flink_http_adapter/__init__.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from dbt.adapters.base import AdapterPlugin
+
+from .connections import FlinkHttpConnectionManager, FlinkHttpCredentials
+from .impl import FlinkHttpAdapter
+
+
+def get_include_path() -> Path:
+    return Path(__file__).parent / "include" / "flink_http"
+
+
+Plugin = AdapterPlugin(
+    adapter=FlinkHttpAdapter,
+    credentials=FlinkHttpCredentials,
+    include_path=str(get_include_path()),
+)
+
+__all__ = ["Plugin", "FlinkHttpAdapter", "FlinkHttpConnectionManager", "FlinkHttpCredentials"]

--- a/adapter/dbt_flink_http_adapter/connections.py
+++ b/adapter/dbt_flink_http_adapter/connections.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import httpx
+from dbt.adapters.sql.connections import SQLConnectionManager
+from dbt.contracts.connection import AdapterResponse, Connection, ConnectionState, Credentials
+from dbt.events.functions import fire_event
+from dbt.events.types import SQLQueryStatus
+from dbt.exceptions import DbtDatabaseError
+
+
+@dataclass
+class FlinkHttpCredentials(Credentials):
+    host: str = ""
+    token: Optional[str] = None
+    database: str = "default_catalog"
+    schema: str = "default_database"
+    timeout_seconds: float = 10.0
+
+    def __post_init__(self) -> None:
+        if not self.host:
+            raise DbtDatabaseError("Flink HTTP credentials require a host URL")
+
+    @property
+    def type(self) -> str:  # type: ignore[override]
+        return "flink_http"
+
+    @property
+    def unique_field(self) -> str:  # type: ignore[override]
+        return self.host
+
+    def _connection_keys(self) -> tuple[str, ...]:
+        return ("host", "schema", "database", "timeout_seconds")
+
+
+@dataclass
+class FlinkHttpResult:
+    job_id: Optional[str]
+    status: str
+    logs_url: Optional[str] = None
+
+
+class FlinkHttpCursor:
+    def __init__(self, client: httpx.Client, credentials: FlinkHttpCredentials) -> None:
+        self._client = client
+        self._credentials = credentials
+        self._last_result: Optional[FlinkHttpResult] = None
+
+    def execute(self, sql: str, bindings: Optional[Any] = None) -> None:  # noqa: ARG002
+        if not sql or not sql.strip():
+            raise DbtDatabaseError("Flink HTTP adapter received an empty SQL payload")
+        headers = {
+            "Content-Type": "application/json",
+            "Idempotency-Key": str(uuid.uuid4()),
+        }
+        if self._credentials.token:
+            headers["Authorization"] = f"Bearer {self._credentials.token}"
+        payload = {"sql": sql}
+        response = self._client.post("/v1/sql", headers=headers, json=payload)
+        try:
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:  # pragma: no cover - exercised via adapter tests
+            message = response.text or exc.args[0]
+            raise DbtDatabaseError(f"Flink SQL proxy returned {response.status_code}: {message}") from exc
+        data: dict[str, Any] = {}
+        if response.content:
+            try:
+                data = response.json()
+            except json.JSONDecodeError:
+                data = {}
+        result = FlinkHttpResult(
+            job_id=data.get("job_id"),
+            status=data.get("status", "SUBMITTED"),
+            logs_url=data.get("logs_url"),
+        )
+        self._last_result = result
+
+    def fetchone(self) -> None:  # pragma: no cover - the adapter never fetches results
+        return None
+
+    def fetchall(self) -> list[Any]:  # pragma: no cover
+        return []
+
+    @property
+    def response(self) -> Optional[FlinkHttpResult]:
+        return self._last_result
+
+
+class FlinkHttpConnection:
+    def __init__(self, credentials: FlinkHttpCredentials) -> None:
+        timeout = httpx.Timeout(credentials.timeout_seconds)
+        self._client = httpx.Client(base_url=credentials.host, timeout=timeout)
+        self._credentials = credentials
+
+    def cursor(self) -> FlinkHttpCursor:
+        return FlinkHttpCursor(self._client, self._credentials)
+
+    def close(self) -> None:
+        self._client.close()
+
+
+class FlinkHttpConnectionManager(SQLConnectionManager):
+    TYPE = "flink_http"
+
+    @classmethod
+    def open(cls, connection: Connection) -> Connection:
+        if connection.state == ConnectionState.OPEN:
+            return connection
+        credentials = connection.credentials
+        if not isinstance(credentials, FlinkHttpCredentials):
+            raise DbtDatabaseError("Invalid credentials type for Flink HTTP adapter")
+        connection.handle = FlinkHttpConnection(credentials)
+        connection.state = ConnectionState.OPEN
+        connection.transaction_open = False
+        return connection
+
+    @classmethod
+    def close(cls, connection: Connection) -> Connection:
+        handle = connection.handle
+        if handle is not None:
+            handle.close()
+        connection.handle = None
+        connection.state = ConnectionState.CLOSED
+        connection.transaction_open = False
+        return connection
+
+    @classmethod
+    def cancel_open(cls, connection: Connection) -> None:  # pragma: no cover - not used
+        handle = connection.handle
+        if handle is not None:
+            handle.close()
+        connection.handle = None
+        connection.state = ConnectionState.CLOSED
+
+    @classmethod
+    def get_response(cls, cursor: FlinkHttpCursor) -> AdapterResponse:
+        result = cursor.response or FlinkHttpResult(job_id=None, status="SUBMITTED")
+        message = result.status
+        if result.job_id:
+            message = f"Job {result.job_id} status={result.status}"
+        response = AdapterResponse(_message=message, code=result.status, rows_affected=None)
+        fire_event(
+            SQLQueryStatus(status=message, elapsed=0.0, node_info=None),
+        )
+        return response
+
+    @classmethod
+    def add_begin_query(cls) -> str:
+        return ""
+
+    @classmethod
+    def add_commit_query(cls) -> str:
+        return ""
+
+    def begin(self) -> None:
+        connection = self.get_thread_connection()
+        connection.transaction_open = False
+
+    def commit(self) -> None:
+        connection = self.get_thread_connection()
+        connection.transaction_open = False

--- a/adapter/dbt_flink_http_adapter/impl.py
+++ b/adapter/dbt_flink_http_adapter/impl.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import agate
+from dbt.adapters.base import BaseRelation
+from dbt.adapters.sql.impl import SQLAdapter
+
+from .connections import FlinkHttpConnectionManager
+
+
+class FlinkHttpAdapter(SQLAdapter):
+    """Minimal dbt adapter that proxies SQL execution to the HTTP service."""
+
+    ConnectionManager = FlinkHttpConnectionManager
+    Relation = BaseRelation
+
+    @classmethod
+    def date_function(cls) -> str:
+        return "CURRENT_DATE"
+
+    @classmethod
+    def convert_text_type(cls, agate_table: agate.Table, col_idx: int) -> str:  # pragma: no cover - defaults unused
+        return "STRING"
+
+    @classmethod
+    def convert_number_type(cls, agate_table: agate.Table, col_idx: int) -> str:
+        return "DECIMAL"
+
+    @classmethod
+    def convert_boolean_type(cls, agate_table: agate.Table, col_idx: int) -> str:
+        return "BOOLEAN"
+
+    @classmethod
+    def convert_datetime_type(cls, agate_table: agate.Table, col_idx: int) -> str:
+        return "TIMESTAMP"
+
+    @classmethod
+    def convert_date_type(cls, agate_table: agate.Table, col_idx: int) -> str:
+        return "DATE"
+
+    @classmethod
+    def convert_time_type(cls, agate_table: agate.Table, col_idx: int) -> str:
+        return "TIME"
+
+    @classmethod
+    def is_cancelable(cls) -> bool:
+        return False

--- a/adapter/dbt_flink_http_adapter/include/flink_http/dbt_project.yml
+++ b/adapter/dbt_flink_http_adapter/include/flink_http/dbt_project.yml
@@ -1,0 +1,6 @@
+name: "flink_http"
+version: "0.1"
+config-version: 2
+
+macro-paths:
+  - macros

--- a/adapter/dbt_flink_http_adapter/include/flink_http/macros/adapters/get_catalog.sql
+++ b/adapter/dbt_flink_http_adapter/include/flink_http/macros/adapters/get_catalog.sql
@@ -1,0 +1,3 @@
+{% macro flink_http__get_catalog(information_schema, schemas) %}
+  {% do return([]) %}
+{% endmacro %}

--- a/adapter/dbt_flink_http_adapter/include/flink_http/macros/adapters/get_columns_in_relation.sql
+++ b/adapter/dbt_flink_http_adapter/include/flink_http/macros/adapters/get_columns_in_relation.sql
@@ -1,0 +1,3 @@
+{% macro flink_http__get_columns_in_relation(relation) %}
+  {% do return([]) %}
+{% endmacro %}

--- a/adapter/dbt_flink_http_adapter/include/flink_http/macros/adapters/list_relations_without_caching.sql
+++ b/adapter/dbt_flink_http_adapter/include/flink_http/macros/adapters/list_relations_without_caching.sql
@@ -1,0 +1,3 @@
+{% macro flink_http__list_relations_without_caching(schema_relation) %}
+  {% do return([]) %}
+{% endmacro %}

--- a/adapter/dbt_flink_http_adapter/include/flink_http/macros/adapters/list_schemas.sql
+++ b/adapter/dbt_flink_http_adapter/include/flink_http/macros/adapters/list_schemas.sql
@@ -1,0 +1,3 @@
+{% macro flink_http__list_schemas(database) %}
+  {% do return([]) %}
+{% endmacro %}

--- a/adapter/dbt_flink_http_adapter/include/flink_http/macros/materializations/table.sql
+++ b/adapter/dbt_flink_http_adapter/include/flink_http/macros/materializations/table.sql
@@ -1,0 +1,7 @@
+{% materialization table, adapter='flink_http' %}
+  {%- set sql = get_create_table_as_sql(False, this, compiled_sql) -%}
+  {% call statement('main', fetch_result=False) %}
+    {{ sql }}
+  {% endcall %}
+  {{ return({'relations': [this]}) }}
+{% endmaterialization %}

--- a/adapter/dbt_flink_http_adapter/include/flink_http/macros/materializations/view.sql
+++ b/adapter/dbt_flink_http_adapter/include/flink_http/macros/materializations/view.sql
@@ -1,0 +1,7 @@
+{% materialization view, adapter='flink_http' %}
+  {%- set sql = get_create_view_sql(this, compiled_sql, or_replace=True) -%}
+  {% call statement('main', fetch_result=False) %}
+    {{ sql }}
+  {% endcall %}
+  {{ return({'relations': [this]}) }}
+{% endmaterialization %}

--- a/adapter/examples/dbt_http_demo/dbt_project.yml
+++ b/adapter/examples/dbt_http_demo/dbt_project.yml
@@ -1,0 +1,10 @@
+name: dbt_http_demo
+version: 1.0
+config-version: 2
+profile: dbt_http_demo
+model-paths:
+  - models
+
+models:
+  dbt_http_demo:
+    +materialized: table

--- a/adapter/examples/dbt_http_demo/models/example.sql
+++ b/adapter/examples/dbt_http_demo/models/example.sql
@@ -1,0 +1,7 @@
+{{ config(materialized='table') }}
+
+with source_data as (
+    select 1 as id, 'hello from dbt over HTTP' as message
+)
+
+select * from source_data

--- a/adapter/pyproject.toml
+++ b/adapter/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "dbt-flink-http-adapter"
+version = "0.1.0"
+description = "Hackathon HTTP adapter that routes dbt SQL execution through the Flink SQL proxy"
+authors = [
+  { name = "Hackathon Team" }
+]
+readme = "README.md"
+requires-python = ">=3.9"
+dependencies = [
+  "dbt-core>=1.4.0,<1.6.0",
+  "httpx>=0.27.0",
+]
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["dbt_flink_http_adapter*"]
+
+[tool.setuptools.package-data]
+dbt_flink_http_adapter = [
+  "include/**/*",
+]

--- a/adapter/tests/test_connection_manager.py
+++ b/adapter/tests/test_connection_manager.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from contextlib import contextmanager
+from types import SimpleNamespace
+
+import httpx
+import pytest
+import respx
+from dbt.contracts.connection import Connection, ConnectionState
+
+# Ensure the adapter package is importable when running tests from repository root
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from dbt_flink_http_adapter.connections import FlinkHttpConnectionManager, FlinkHttpCredentials  # noqa: E402
+
+
+class TestConnectionManager(FlinkHttpConnectionManager):
+    @contextmanager
+    def exception_handler(self, sql: str):  # type: ignore[override]
+        yield
+
+    def cancel(self, connection: Connection) -> None:  # type: ignore[override]
+        return
+
+
+@pytest.fixture
+def manager() -> FlinkHttpConnectionManager:
+    profile = SimpleNamespace()
+    return TestConnectionManager(profile)
+
+
+@respx.mock
+def test_add_query_posts_to_proxy(manager: FlinkHttpConnectionManager) -> None:
+    credentials = FlinkHttpCredentials(host="http://proxy:8080")
+    connection = Connection(
+        type="flink_http",
+        name="test",
+        state=ConnectionState.INIT,
+        handle=None,
+        credentials=credentials,
+    )
+    manager.set_thread_connection(connection)
+    manager.open(connection)
+    respx.post("http://proxy:8080/v1/sql").mock(
+        return_value=httpx.Response(200, json={"job_id": "job-1", "status": "RUNNING"})
+    )
+    _, cursor = manager.add_query("SELECT 1", auto_begin=False)
+    response = manager.get_response(cursor)
+    assert response.code == "RUNNING"
+    assert "job-1" in str(response)
+    assert respx.calls.call_count == 1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -14,9 +14,16 @@ pytest-dotenv
 pytest-logbook
 pytest-csv
 pytest-xdist
+pytest-asyncio
 pytz
 tox>=3.13
 twine
 wheel
 requests
 pyyaml
+fastapi>=0.110,<0.115
+httpx>=0.27,<0.28
+uvicorn[standard]>=0.23,<0.25
+respx>=0.20,<0.21
+asgi-lifespan>=2.1,<2.2
+pydantic-settings>=2.1,<2.3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+version: "3.9"
+
+services:
+  jobmanager:
+    image: flink:1.17.2-scala_2.12
+    hostname: jobmanager
+    command: jobmanager
+    environment:
+      - |
+        FLINK_PROPERTIES=
+          jobmanager.rpc.address: jobmanager
+          rest.address: 0.0.0.0
+          rest.port: 8081
+    ports:
+      - "8081:8081"
+
+  taskmanager:
+    image: flink:1.17.2-scala_2.12
+    depends_on:
+      - jobmanager
+    command: taskmanager
+    environment:
+      - |
+        FLINK_PROPERTIES=
+          jobmanager.rpc.address: jobmanager
+          taskmanager.numberOfTaskSlots: 4
+
+  flink-sql-proxy:
+    build: .
+    environment:
+      FLINK_REST_URL: http://jobmanager:8081
+      FLINK_APPLICATION_NAME: sql-runner
+      AUTH_TOKEN: hackathon
+    ports:
+      - "8080:8080"
+    depends_on:
+      - jobmanager

--- a/envs/flink-1.16/docker-compose.yml
+++ b/envs/flink-1.16/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.9"
+
+services:
+  jobmanager:
+    extends:
+      file: ../../docker-compose.yml
+      service: jobmanager
+  taskmanager:
+    extends:
+      file: ../../docker-compose.yml
+      service: taskmanager
+  flink-sql-proxy:
+    extends:
+      file: ../../docker-compose.yml
+      service: flink-sql-proxy

--- a/proxy/config.py
+++ b/proxy/config.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from typing import List, Optional
+
+from pydantic import AnyHttpUrl, Field, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Runtime configuration for the SQL proxy."""
+
+    flink_rest_url: AnyHttpUrl = Field(
+        "http://jobmanager:8081", env="FLINK_REST_URL", description="Base REST endpoint for the Flink cluster"
+    )
+    flink_application_name: str = Field(
+        "sql-runner",
+        env="FLINK_APPLICATION_NAME",
+        description="Human friendly name for the long running application job used to execute SQL statements.",
+    )
+    flink_application_job_id: Optional[str] = Field(
+        None,
+        env="FLINK_APPLICATION_JOB_ID",
+        description="Explicit job identifier to reuse when routing SQL to a long running application job.",
+    )
+    flink_application_jar_path: Optional[Path] = Field(
+        None,
+        env="FLINK_APPLICATION_JAR_PATH",
+        description="Local path to an application JAR that should be uploaded if the target job is not yet running.",
+    )
+    flink_application_entry_class: Optional[str] = Field(
+        None,
+        env="FLINK_APPLICATION_ENTRY_CLASS",
+        description="Fully qualified entry class for launching the long running application job in Flink.",
+    )
+    flink_application_program_args: List[str] = Field(
+        default_factory=list,
+        env="FLINK_APPLICATION_PROGRAM_ARGS",
+        description="Additional program arguments to forward when launching the application job.",
+    )
+    flink_statement_endpoint: Optional[str] = Field(
+        None,
+        env="FLINK_STATEMENT_ENDPOINT",
+        description=(
+            "Optional relative or absolute URL exposed by the long running application job that accepts SQL payloads. "
+            "If not provided, the proxy will attempt to post to /jobs/{job_id}/control/submit-sql on the Flink REST API."
+        ),
+    )
+    auth_token: Optional[str] = Field(
+        None,
+        env="AUTH_TOKEN",
+        description="Optional bearer token expected in Authorization headers. If set, requests must provide a matching token.",
+    )
+    logs_base_url: Optional[AnyHttpUrl] = Field(
+        None,
+        env="FLINK_LOGS_BASE_URL",
+        description="Base URL for constructing links to Flink job logs in responses.",
+    )
+    http_timeout_seconds: float = Field(10.0, env="HTTP_TIMEOUT_SECONDS", ge=1.0, le=120.0)
+    idempotency_ttl_seconds: int = Field(600, env="IDEMPOTENCY_TTL_SECONDS", ge=1, le=3600)
+    stderr_truncate_bytes: int = Field(2048, env="STDERR_TRUNCATE_BYTES", ge=256, le=16384)
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", case_sensitive=False)
+
+    @field_validator("flink_application_program_args", mode="before")
+    @classmethod
+    def _split_program_args(cls, value):
+        if isinstance(value, str):
+            return [item for item in value.split() if item]
+        return value
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    return Settings()

--- a/proxy/examples/example.sql
+++ b/proxy/examples/example.sql
@@ -1,0 +1,10 @@
+-- Example multi-statement payload that can be posted to the proxy.
+CREATE TABLE demo_sink (
+    id INT,
+    payload STRING
+) WITH (
+    'connector' = 'blackhole'
+);
+
+INSERT INTO demo_sink
+SELECT 1 AS id, 'hello from the proxy' AS payload;

--- a/proxy/flink_client.py
+++ b/proxy/flink_client.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+from urllib.parse import urljoin
+
+import httpx
+
+from .config import Settings
+from .schemas import SqlResponse
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class FlinkJob:
+    job_id: str
+    state: str
+    name: Optional[str] = None
+
+    def is_running(self) -> bool:
+        return self.state.upper() in {"CREATED", "RUNNING", "RECONCILING", "INITIALIZING"}
+
+
+class FlinkProxyError(Exception):
+    """Base class for failures interacting with the Flink REST API."""
+
+
+class FlinkJobNotAvailableError(FlinkProxyError):
+    """Raised when no suitable application job is available."""
+
+
+class FlinkSubmissionError(FlinkProxyError):
+    def __init__(self, message: str, status_code: int, body: str) -> None:
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+        self.body = body
+
+    def as_payload(self, truncate_bytes: int) -> Dict[str, str]:
+        stderr = self.body
+        if len(stderr) > truncate_bytes:
+            stderr = stderr[:truncate_bytes] + "..."
+        payload = {"error": self.message, "stderr": stderr}
+        return payload
+
+
+class FlinkApplicationClient:
+    """Minimal client that routes SQL statements to a long running Flink application job."""
+
+    def __init__(self, settings: Settings, client: httpx.AsyncClient) -> None:
+        self._settings = settings
+        self._client = client
+        self._statement_client: Optional[httpx.AsyncClient] = None
+        self._job_cache: Optional[FlinkJob] = None
+        self._jar_id: Optional[str] = None
+        self._lock = asyncio.Lock()
+
+    async def submit_sql(self, sql: str, variables: Dict[str, str]) -> SqlResponse:
+        job = await self.ensure_application_job()
+        response = await self._dispatch_sql(job, sql, variables)
+        if not response.job_id:
+            response.job_id = job.job_id
+        if not response.logs_url:
+            response.logs_url = self._build_logs_url(job.job_id)
+        return response
+
+    async def ensure_application_job(self) -> FlinkJob:
+        async with self._lock:
+            if self._job_cache and self._job_cache.is_running():
+                return self._job_cache
+
+            job = await self._find_running_job()
+            if job:
+                self._job_cache = job
+                return job
+
+            job = await self._maybe_launch_job()
+            if job:
+                self._job_cache = job
+                return job
+
+            raise FlinkJobNotAvailableError(
+                "No running Flink application job found. Configure FLINK_APPLICATION_JOB_ID or provide a launchable JAR."
+            )
+
+    async def _find_running_job(self) -> Optional[FlinkJob]:
+        # Prefer explicit job ID when provided to avoid scanning
+        if self._settings.flink_application_job_id:
+            job = await self._get_job(self._settings.flink_application_job_id)
+            if job and job.is_running():
+                return job
+            return None
+
+        overview = await self._client.get("/jobs/overview")
+        overview.raise_for_status()
+        data = overview.json()
+        jobs = data.get("jobs", [])
+        for job_entry in jobs:
+            state = job_entry.get("state", "")
+            job_name = job_entry.get("name")
+            job_id = job_entry.get("jid") or job_entry.get("jobid")
+            if not job_id:
+                continue
+            if job_name and job_name != self._settings.flink_application_name:
+                continue
+            job = FlinkJob(job_id=job_id, state=state, name=job_name)
+            if job.is_running():
+                return job
+        return None
+
+    async def _get_job(self, job_id: str) -> Optional[FlinkJob]:
+        response = await self._client.get(f"/jobs/{job_id}")
+        if response.status_code == httpx.codes.NOT_FOUND:
+            return None
+        response.raise_for_status()
+        payload = response.json()
+        name = payload.get("name") or self._settings.flink_application_name
+        state = payload.get("state", "UNKNOWN")
+        return FlinkJob(job_id=job_id, state=state, name=name)
+
+    async def _maybe_launch_job(self) -> Optional[FlinkJob]:
+        jar_path = self._settings.flink_application_jar_path
+        if not jar_path:
+            return None
+        jar_id = await self._ensure_jar_uploaded(jar_path)
+        params = {"mode": "application"}
+        payload: Dict[str, Any] = {}
+        if self._settings.flink_application_entry_class:
+            payload["entryClass"] = self._settings.flink_application_entry_class
+        if self._settings.flink_application_program_args:
+            payload["programArgsList"] = self._settings.flink_application_program_args
+        response = await self._client.post(f"/jars/{jar_id}/run", params=params, json=payload)
+        response.raise_for_status()
+        data = response.json()
+        job_id = data.get("jobid") or data.get("job_id")
+        if not job_id:
+            raise FlinkSubmissionError("Flink did not return a job id when launching the application", response.status_code, json.dumps(data))
+        logger.info("Launched Flink application job %s", job_id)
+        return FlinkJob(job_id=job_id, state="RUNNING", name=self._settings.flink_application_name)
+
+    async def _ensure_jar_uploaded(self, jar_path: Path) -> str:
+        if self._jar_id:
+            return self._jar_id
+        if not jar_path.exists():
+            raise FlinkSubmissionError(
+                f"Application JAR '{jar_path}' is not accessible inside the proxy container",
+                status_code=400,
+                body="",
+            )
+        jar_bytes = jar_path.read_bytes()
+        files = {"jarfile": (jar_path.name, jar_bytes, "application/java-archive")}
+        response = await self._client.post("/jars/upload", files=files)
+        response.raise_for_status()
+        data = response.json()
+        filename = data.get("filename")
+        if not filename:
+            raise FlinkSubmissionError("Unable to determine uploaded JAR identifier", response.status_code, json.dumps(data))
+        jar_id = Path(filename).name
+        self._jar_id = jar_id
+        logger.info("Uploaded application jar %s", jar_id)
+        return jar_id
+
+    async def _dispatch_sql(self, job: FlinkJob, sql: str, variables: Dict[str, str]) -> SqlResponse:
+        endpoint = self._settings.flink_statement_endpoint
+        payload = {"sql": sql, "vars": variables, "job_id": job.job_id}
+        if endpoint:
+            url = endpoint.format(job_id=job.job_id)
+            client = await self._get_statement_client(url)
+            if client is self._client and not url.startswith("/"):
+                url = "/" + url
+            response = await client.post(url, json=payload)
+        else:
+            response = await self._client.post(f"/jobs/{job.job_id}/control/submit-sql", json=payload)
+        if response.status_code >= 400:
+            text = response.text or ""
+            raise FlinkSubmissionError(
+                f"Flink REST API returned {response.status_code} when submitting SQL", response.status_code, text
+            )
+        if response.status_code == httpx.codes.NO_CONTENT:
+            return SqlResponse(job_id=job.job_id, status="SUBMITTED", logs_url=self._build_logs_url(job.job_id))
+        data = response.json() if response.content else {}
+        status = data.get("status", "SUBMITTED")
+        logs_url = data.get("logs_url")
+        job_id = data.get("job_id") or job.job_id
+        return SqlResponse(job_id=job_id, status=status, logs_url=logs_url)
+
+    async def _get_statement_client(self, url: str) -> httpx.AsyncClient:
+        if url.startswith("http://") or url.startswith("https://"):
+            if self._statement_client is None or self._statement_client.is_closed:
+                self._statement_client = httpx.AsyncClient(timeout=self._settings.http_timeout_seconds)
+            return self._statement_client
+        return self._client
+
+    def _build_logs_url(self, job_id: str) -> Optional[str]:
+        if self._settings.logs_base_url:
+            return urljoin(str(self._settings.logs_base_url), job_id)
+        base = str(self._settings.flink_rest_url).rstrip("/")
+        return f"{base}/#/job/{job_id}"
+
+    async def close(self) -> None:
+        if self._statement_client and not self._statement_client.is_closed:
+            await self._statement_client.aclose()

--- a/proxy/idempotency.py
+++ b/proxy/idempotency.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Dict, Generic, Optional, TypeVar
+
+
+T = TypeVar("T")
+
+
+class IdempotencyCache(Generic[T]):
+    """An in-memory cache with TTL semantics used for idempotent responses."""
+
+    def __init__(self, ttl_seconds: int) -> None:
+        self._ttl_seconds = ttl_seconds
+        self._store: Dict[str, tuple[float, T]] = {}
+        self._lock = asyncio.Lock()
+
+    async def get(self, key: str) -> Optional[T]:
+        async with self._lock:
+            self._prune()
+            entry = self._store.get(key)
+            if not entry:
+                return None
+            timestamp, value = entry
+            if time.monotonic() - timestamp > self._ttl_seconds:
+                self._store.pop(key, None)
+                return None
+            return value
+
+    async def set(self, key: str, value: T) -> None:
+        async with self._lock:
+            self._prune()
+            self._store[key] = (time.monotonic(), value)
+
+    async def clear(self) -> None:
+        async with self._lock:
+            self._store.clear()
+
+    def _prune(self) -> None:
+        if not self._store:
+            return
+        cutoff = time.monotonic() - self._ttl_seconds
+        expired = [cache_key for cache_key, (ts, _) in self._store.items() if ts < cutoff]
+        for cache_key in expired:
+            self._store.pop(cache_key, None)

--- a/proxy/main.py
+++ b/proxy/main.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import logging
+import secrets
+from typing import Optional
+
+import httpx
+from fastapi import Depends, FastAPI, Header, HTTPException, Request, status
+
+from .config import Settings, get_settings
+from .flink_client import FlinkApplicationClient, FlinkJobNotAvailableError, FlinkSubmissionError
+from .idempotency import IdempotencyCache
+from .schemas import ErrorResponse, SqlRequest, SqlResponse
+
+logger = logging.getLogger(__name__)
+
+
+def create_app(settings: Optional[Settings] = None) -> FastAPI:
+    if settings is None:
+        settings = get_settings()
+
+    app = FastAPI(title="Flink SQL Proxy", version="0.1.0")
+    cache = IdempotencyCache[SqlResponse](settings.idempotency_ttl_seconds)
+
+    app.state.settings = settings
+    app.state.idempotency_cache = cache
+    app.dependency_overrides[get_settings] = lambda: settings
+
+    @app.on_event("startup")
+    async def _startup() -> None:
+        logger.info("Starting Flink SQL proxy targeting %s", settings.flink_rest_url)
+        timeout = httpx.Timeout(settings.http_timeout_seconds)
+        app.state.http_client = httpx.AsyncClient(base_url=str(settings.flink_rest_url), timeout=timeout)
+        app.state.flink_client = FlinkApplicationClient(settings, app.state.http_client)
+
+    @app.on_event("shutdown")
+    async def _shutdown() -> None:
+        logger.info("Shutting down Flink SQL proxy")
+        flink_client: FlinkApplicationClient = app.state.flink_client
+        await flink_client.close()
+        await app.state.http_client.aclose()
+
+    @app.get("/healthz", response_model=dict)
+    async def healthcheck() -> dict:
+        return {"status": "ok"}
+
+    @app.post("/v1/sql", response_model=SqlResponse, responses={502: {"model": ErrorResponse}})
+    async def submit_sql(
+        payload: SqlRequest,
+        request: Request,
+        settings: Settings = Depends(get_settings),
+        authorization: Optional[str] = Header(default=None),
+        idempotency_header: Optional[str] = Header(default=None, alias="Idempotency-Key"),
+    ) -> SqlResponse:
+        _authenticate(settings, authorization)
+        cache: IdempotencyCache[SqlResponse] = request.app.state.idempotency_cache
+        key = idempotency_header or payload.idempotency_key
+        if key:
+            cached = await cache.get(key)
+            if cached:
+                logger.debug("Returning cached result for idempotency key %s", key)
+                return cached
+        try:
+            flink_client: FlinkApplicationClient = request.app.state.flink_client
+        except AttributeError as exc:  # pragma: no cover - should not happen after startup
+            logger.exception("Flink client not initialised")
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Proxy not initialised") from exc
+        try:
+            response = await flink_client.submit_sql(payload.sql, payload.variables)
+        except FlinkJobNotAvailableError as exc:
+            logger.warning("Unable to locate running Flink application job: %s", exc)
+            raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc)) from exc
+        except FlinkSubmissionError as exc:
+            logger.error("Flink submission failed: %s", exc)
+            detail = exc.as_payload(settings.stderr_truncate_bytes)
+            raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=detail) from exc
+        except httpx.HTTPError as exc:
+            logger.error("HTTP error while communicating with Flink: %s", exc)
+            detail = {"error": "Flink REST API request failed", "stderr": str(exc)}
+            raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=detail) from exc
+        if key:
+            await cache.set(key, response)
+        return response
+
+    return app
+
+
+def _authenticate(settings: Settings, authorization: Optional[str]) -> None:
+    expected = settings.auth_token
+    if not expected:
+        return
+    if not authorization or not authorization.lower().startswith("bearer "):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing bearer token")
+    provided = authorization.split(" ", 1)[1].strip()
+    if not secrets.compare_digest(expected, provided):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid bearer token")
+
+
+app = create_app()

--- a/proxy/requirements.txt
+++ b/proxy/requirements.txt
@@ -1,0 +1,4 @@
+fastapi>=0.110,<0.115
+httpx>=0.27,<0.28
+uvicorn[standard]>=0.23,<0.25
+pydantic-settings>=2.1,<2.3

--- a/proxy/schemas.py
+++ b/proxy/schemas.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+from pydantic import AnyHttpUrl, BaseModel, Field, constr
+
+
+class SqlRequest(BaseModel):
+    sql: constr(strip_whitespace=True, min_length=1)  # type: ignore[valid-type]
+    variables: Dict[str, str] = Field(default_factory=dict, alias="vars")
+    idempotency_key: Optional[str] = Field(None, alias="idempotency_key")
+
+    class Config:
+        allow_population_by_field_name = True
+        anystr_strip_whitespace = True
+
+
+class SqlResponse(BaseModel):
+    job_id: str
+    status: str
+    logs_url: Optional[AnyHttpUrl] = None
+
+
+class ErrorResponse(BaseModel):
+    detail: str
+    error: Optional[str] = None
+    stderr: Optional[str] = None

--- a/proxy/tests/test_sql_endpoint.py
+++ b/proxy/tests/test_sql_endpoint.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from typing import AsyncIterator
+
+import httpx
+import pytest
+import pytest_asyncio
+import respx
+from asgi_lifespan import LifespanManager
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from proxy.config import Settings
+from proxy.main import create_app
+
+
+@pytest_asyncio.fixture
+async def app() -> AsyncIterator[httpx.AsyncClient]:
+    settings = Settings(
+        flink_rest_url="http://flink:8081",
+        auth_token="secret",
+        logs_base_url="http://jobmanager:8081/#/job/",
+    )
+    fastapi_app = create_app(settings)
+    async with LifespanManager(fastapi_app):
+        async with httpx.AsyncClient(app=fastapi_app, base_url="http://test") as client:
+            yield client
+
+
+@pytest.fixture
+def respx_routes() -> respx.MockRouter:
+    with respx.mock(base_url="http://flink:8081", assert_all_called=False) as router:
+        yield router
+
+
+@pytest.mark.asyncio
+async def test_submit_sql_success(app: httpx.AsyncClient, respx_routes: respx.MockRouter) -> None:
+    respx_routes.get("/jobs/overview").mock(
+        return_value=httpx.Response(
+            200,
+            json={"jobs": [{"jid": "abc123", "state": "RUNNING", "name": "sql-runner"}]},
+        )
+    )
+    respx_routes.post("/jobs/abc123/control/submit-sql").mock(
+        return_value=httpx.Response(
+            200,
+            json={"job_id": "abc123", "status": "ACCEPTED", "logs_url": "http://jm/jobs/abc123"},
+        )
+    )
+    response = await app.post(
+        "/v1/sql",
+        headers={"Authorization": "Bearer secret", "Idempotency-Key": "demo"},
+        json={"sql": "SELECT 1", "vars": {}},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["job_id"] == "abc123"
+    assert body["status"] == "ACCEPTED"
+    assert body["logs_url"].endswith("abc123")
+
+
+@pytest.mark.asyncio
+async def test_authentication_required(app: httpx.AsyncClient) -> None:
+    response = await app.post("/v1/sql", json={"sql": "SELECT 1"})
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_idempotency_returns_cached_result(app: httpx.AsyncClient, respx_routes: respx.MockRouter) -> None:
+    respx_routes.get("/jobs/overview").mock(
+        return_value=httpx.Response(
+            200,
+            json={"jobs": [{"jid": "xyz", "state": "RUNNING", "name": "sql-runner"}]},
+        )
+    )
+    respx_routes.post("/jobs/xyz/control/submit-sql").mock(
+        side_effect=[
+            httpx.Response(200, json={"job_id": "xyz", "status": "RUNNING"}),
+            httpx.Response(200, json={"job_id": "xyz", "status": "RUNNING"}),
+        ]
+    )
+    headers = {"Authorization": "Bearer secret", "Idempotency-Key": "abc"}
+    payload = {"sql": "SELECT 1", "vars": {}}
+    first = await app.post("/v1/sql", headers=headers, json=payload)
+    second = await app.post("/v1/sql", headers=headers, json=payload)
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert respx_routes.calls.call_count == 2  # overview + first execution, second hits cache
+    assert first.json() == second.json()
+
+
+@pytest.mark.asyncio
+async def test_flink_error_maps_to_502(app: httpx.AsyncClient, respx_routes: respx.MockRouter) -> None:
+    respx_routes.get("/jobs/overview").mock(
+        return_value=httpx.Response(
+            200,
+            json={"jobs": [{"jid": "xyz", "state": "RUNNING", "name": "sql-runner"}]},
+        )
+    )
+    respx_routes.post("/jobs/xyz/control/submit-sql").mock(
+        return_value=httpx.Response(500, text="boom"),
+    )
+    response = await app.post(
+        "/v1/sql",
+        headers={"Authorization": "Bearer secret"},
+        json={"sql": "SELECT 1"},
+    )
+    assert response.status_code == 502
+    body = response.json()
+    assert body["detail"]["stderr"].startswith("boom")
+
+
+@pytest.mark.asyncio
+async def test_empty_sql_rejected(app: httpx.AsyncClient) -> None:
+    response = await app.post(
+        "/v1/sql",
+        headers={"Authorization": "Bearer secret"},
+        json={"sql": "   "},
+    )
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary
- add a FastAPI-based SQL proxy with auth, idempotency caching, and a Flink REST client plus unit tests
- create a minimal dbt HTTP adapter package, macros, and accompanying tests and examples
- provide container tooling, documentation updates, and sample SQL/dbt assets for the hackathon workflow

## Testing
- `pytest proxy/tests adapter/tests`


------
https://chatgpt.com/codex/tasks/task_e_68c96bf407648321afee610251991d6f